### PR TITLE
Feature/add statistics database insights

### DIFF
--- a/lib/configs/hive_adapter_type.dart
+++ b/lib/configs/hive_adapter_type.dart
@@ -2,5 +2,5 @@
 class HiveAdapterType {
   static const noun = 0;
   static const category = 1;
-  static const playerData = 2;
+  static const playerNounData = 2;
 }

--- a/lib/configs/hive_adapter_type.dart
+++ b/lib/configs/hive_adapter_type.dart
@@ -3,4 +3,5 @@ class HiveAdapterType {
   static const noun = 0;
   static const category = 1;
   static const playerNounData = 2;
+  static const playerDailyData = 3;
 }

--- a/lib/models/player_daily_data.dart
+++ b/lib/models/player_daily_data.dart
@@ -1,0 +1,41 @@
+import 'package:hive/hive.dart';
+import 'package:meta/meta.dart';
+
+import 'package:elola/configs/hive_adapter_type.dart';
+
+part 'player_daily_data.g.dart';
+
+/// A model represeting a player's data on daily progress
+@HiveType(typeId: HiveAdapterType.playerDailyData)
+class PlayerDailyData {
+  /// An id representing the date
+  @HiveField(0)
+  final String id;
+
+  /// The number of new nouns learned
+  @HiveField(1)
+  int nounsLearned;
+
+  /// The number learned nouns practiced
+  @HiveField(2)
+  int nounsPracticed;
+
+  /// The total time spent
+  @HiveField(3)
+  double timeSpent;
+
+  PlayerDailyData({@required this.id});
+
+  /// The date which this data corresponds to
+  DateTime get date => DateTime.tryParse(id);
+
+  /// Resets the progress
+  // void reset() {
+  //   nounsLearned = 0;
+  //   nounsPracticed = 0;
+  //   timeSpent = 0;
+  // }
+
+  @override
+  String toString() => '{$id: {nounsLearned: $nounsLearned, nounsPracticed: $nounsPracticed, timeSpent: $timeSpent}}';
+}

--- a/lib/models/player_daily_data.dart
+++ b/lib/models/player_daily_data.dart
@@ -20,7 +20,7 @@ class PlayerDailyData {
   @HiveField(2)
   int nounsPracticed;
 
-  /// The total time spent
+  /// The total time spent (im ms)
   @HiveField(3)
   double timeSpent;
 
@@ -29,12 +29,12 @@ class PlayerDailyData {
   /// The date which this data corresponds to
   DateTime get date => DateTime.tryParse(id);
 
-  /// Resets the progress
-  // void reset() {
-  //   nounsLearned = 0;
-  //   nounsPracticed = 0;
-  //   timeSpent = 0;
-  // }
+  /// Inits the model
+  void init() {
+    nounsLearned = 0;
+    nounsPracticed = 0;
+    timeSpent = 0;
+  }
 
   @override
   String toString() => '{$id: {nounsLearned: $nounsLearned, nounsPracticed: $nounsPracticed, timeSpent: $timeSpent}}';

--- a/lib/models/player_daily_data.g.dart
+++ b/lib/models/player_daily_data.g.dart
@@ -1,0 +1,40 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'player_daily_data.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class PlayerDailyDataAdapter extends TypeAdapter<PlayerDailyData> {
+  @override
+  final typeId = 3;
+
+  @override
+  PlayerDailyData read(BinaryReader reader) {
+    var numOfFields = reader.readByte();
+    var fields = <int, dynamic>{
+      for (var i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return PlayerDailyData(
+      id: fields[0] as String,
+    )
+      ..nounsLearned = fields[1] as int
+      ..nounsPracticed = fields[2] as int
+      ..timeSpent = fields[3] as double;
+  }
+
+  @override
+  void write(BinaryWriter writer, PlayerDailyData obj) {
+    writer
+      ..writeByte(4)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.nounsLearned)
+      ..writeByte(2)
+      ..write(obj.nounsPracticed)
+      ..writeByte(3)
+      ..write(obj.timeSpent);
+  }
+}

--- a/lib/models/player_noun_data.dart
+++ b/lib/models/player_noun_data.dart
@@ -24,10 +24,19 @@ class PlayerNounData {
   @HiveField(3)
   bool isFavorite;
 
+  /// When the noun was last seen
+  @HiveField(4)
+  DateTime lastSeen;
+
   PlayerNounData({@required this.id});
 
+  /// Whether the noun is learned
+  ///
+  /// In the future this could be calculated more inteligently, i.e. considering lastSeen
+  bool get isLearned => attempts > 0;
+
   /// The percentage (between 0 and 1) that the player was correct
-  double get percentageCorrect => attempts > 0 ? timesCorrect / attempts : 0;
+  double get percentageCorrect => isLearned ? timesCorrect / attempts : 0;
 
   /// Updates the progress
   void updateProgress({@required bool answeredCorrectly}) {
@@ -35,6 +44,7 @@ class PlayerNounData {
     if (answeredCorrectly) {
       timesCorrect++;
     }
+    lastSeen = DateTime.now().toUtc();
   }
 
   /// Resets the progress
@@ -42,9 +52,10 @@ class PlayerNounData {
     attempts = 0;
     timesCorrect = 0;
     isFavorite = false;
+    lastSeen = null;
   }
 
   @override
   String toString() =>
-      '{$id: {attempts: $attempts, timesCorrect: $timesCorrect, isFavorite: $isFavorite, percentageCorrect: $percentageCorrect}}';
+      '{$id: {attempts: $attempts, timesCorrect: $timesCorrect, isFavorite: $isFavorite, isLearned: $isLearned, percentageCorrect: $percentageCorrect, lastSeen: $lastSeen}}';
 }

--- a/lib/models/player_noun_data.dart
+++ b/lib/models/player_noun_data.dart
@@ -3,11 +3,11 @@ import 'package:meta/meta.dart';
 
 import 'package:elola/configs/hive_adapter_type.dart';
 
-part 'player_data.g.dart';
+part 'player_noun_data.g.dart';
 
 /// A model represeting a player's data on a given noun
-@HiveType(typeId: HiveAdapterType.playerData)
-class PlayerData {
+@HiveType(typeId: HiveAdapterType.playerNounData)
+class PlayerNounData {
   /// The noun's id
   @HiveField(0)
   final String id;
@@ -24,7 +24,7 @@ class PlayerData {
   @HiveField(3)
   bool isFavorite;
 
-  PlayerData({@required this.id});
+  PlayerNounData({@required this.id});
 
   /// The percentage (between 0 and 1) that the player was correct
   double get percentageCorrect => attempts > 0 ? timesCorrect / attempts : 0;

--- a/lib/models/player_noun_data.g.dart
+++ b/lib/models/player_noun_data.g.dart
@@ -21,13 +21,14 @@ class PlayerNounDataAdapter extends TypeAdapter<PlayerNounData> {
     )
       ..attempts = fields[1] as int
       ..timesCorrect = fields[2] as int
-      ..isFavorite = fields[3] as bool;
+      ..isFavorite = fields[3] as bool
+      ..lastSeen = fields[4] as DateTime;
   }
 
   @override
   void write(BinaryWriter writer, PlayerNounData obj) {
     writer
-      ..writeByte(4)
+      ..writeByte(5)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -35,6 +36,8 @@ class PlayerNounDataAdapter extends TypeAdapter<PlayerNounData> {
       ..writeByte(2)
       ..write(obj.timesCorrect)
       ..writeByte(3)
-      ..write(obj.isFavorite);
+      ..write(obj.isFavorite)
+      ..writeByte(4)
+      ..write(obj.lastSeen);
   }
 }

--- a/lib/models/player_noun_data.g.dart
+++ b/lib/models/player_noun_data.g.dart
@@ -1,22 +1,22 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'player_data.dart';
+part of 'player_noun_data.dart';
 
 // **************************************************************************
 // TypeAdapterGenerator
 // **************************************************************************
 
-class PlayerDataAdapter extends TypeAdapter<PlayerData> {
+class PlayerNounDataAdapter extends TypeAdapter<PlayerNounData> {
   @override
   final typeId = 2;
 
   @override
-  PlayerData read(BinaryReader reader) {
+  PlayerNounData read(BinaryReader reader) {
     var numOfFields = reader.readByte();
     var fields = <int, dynamic>{
       for (var i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
-    return PlayerData(
+    return PlayerNounData(
       id: fields[0] as String,
     )
       ..attempts = fields[1] as int
@@ -25,7 +25,7 @@ class PlayerDataAdapter extends TypeAdapter<PlayerData> {
   }
 
   @override
-  void write(BinaryWriter writer, PlayerData obj) {
+  void write(BinaryWriter writer, PlayerNounData obj) {
     writer
       ..writeByte(4)
       ..writeByte(0)

--- a/lib/modules/noun_of_the_day/src/services/noun_of_the_day_service.dart
+++ b/lib/modules/noun_of_the_day/src/services/noun_of_the_day_service.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart' show rootBundle;
 
+import 'package:elola/utils/date_time_utils.dart';
+
 import 'i_noun_of_the_day_service.dart';
 import '../models/import_model.dart';
 
@@ -28,10 +30,7 @@ class NounOfTheDayService implements INounOfTheDayService {
   /// `null` implies that there is no valid noun for today
   String get today {
     if (_hasValidData) {
-      final nowUtc = DateTime.now().toUtc();
-      final todayUtcMidnight = DateTime.utc(nowUtc.year, nowUtc.month, nowUtc.day);
-      final numberDaysSinceCycleBegan = todayUtcMidnight.difference(_startDate).inDays;
-
+      final numberDaysSinceCycleBegan = DateTimeUtils.todayUtcMidnight.difference(_startDate).inDays;
       if (numberDaysSinceCycleBegan >= 0) {
         final index = numberDaysSinceCycleBegan % _cycleLength;
         return _order[index];

--- a/lib/modules/player_data/src/services/i_player_data_service.dart
+++ b/lib/modules/player_data/src/services/i_player_data_service.dart
@@ -2,7 +2,7 @@ import 'package:meta/meta.dart';
 
 import 'package:elola/services/i_database.dart';
 
-/// A database of the player's data
+/// A service which interacts with player data databases
 abstract class IPlayerDataService implements IDatabase {
   /// Ensures that the database is in sync with a list of noun ids
   Future<void> resync({@required Iterable<String> ids});

--- a/lib/modules/player_data/src/services/i_player_data_service.dart
+++ b/lib/modules/player_data/src/services/i_player_data_service.dart
@@ -1,9 +1,9 @@
 import 'package:meta/meta.dart';
 
-import 'package:elola/services/i_database.dart';
+import 'package:elola/services/i_service.dart';
 
 /// A service which interacts with player data databases
-abstract class IPlayerDataService implements IDatabase {
+abstract class IPlayerDataService implements IService {
   /// Ensures that the database is in sync with a list of noun ids
   Future<void> resync({@required Iterable<String> ids});
 

--- a/lib/modules/player_data/src/services/i_player_data_service.dart
+++ b/lib/modules/player_data/src/services/i_player_data_service.dart
@@ -10,6 +10,9 @@ abstract class IPlayerDataService implements IService {
   /// Updates the progress of a given noun
   void updateProgress({@required String id, @required bool answeredCorrectly});
 
+  /// Updates the time the user has spent playing
+  void updateTimeSpent({@required isPlaying});
+
   /// Returns the player's total progress
   double get totalProgress;
 

--- a/lib/modules/player_data/src/services/player_daily_data/i_player_daily_data_database.dart
+++ b/lib/modules/player_data/src/services/player_daily_data/i_player_daily_data_database.dart
@@ -1,0 +1,9 @@
+import 'package:meta/meta.dart';
+
+import 'package:elola/services/i_database.dart';
+
+/// A database of the player's daily data
+abstract class IPlayerDailyDataDatabase implements IDatabase {
+  /// Updates the progress of a given day
+  void updateProgress({@required String id, @required bool isLearned});
+}

--- a/lib/modules/player_data/src/services/player_daily_data/i_player_daily_data_database.dart
+++ b/lib/modules/player_data/src/services/player_daily_data/i_player_daily_data_database.dart
@@ -4,6 +4,12 @@ import 'package:elola/services/i_database.dart';
 
 /// A database of the player's daily data
 abstract class IPlayerDailyDataDatabase implements IDatabase {
+  /// Ensures that data exists for an id, creating an instance if required
+  void ensureDataExists({@required String id});
+
   /// Updates the progress of a given day
   void updateProgress({@required String id, @required bool isLearned});
+
+  /// Updates the time spent on a given day
+  void updateTimeSpent({@required String id, @required int timeSpent});
 }

--- a/lib/modules/player_data/src/services/player_daily_data/player_daily_data_database.dart
+++ b/lib/modules/player_data/src/services/player_daily_data/player_daily_data_database.dart
@@ -1,0 +1,36 @@
+import 'package:meta/meta.dart';
+
+import 'package:elola/models/player_daily_data.dart';
+import 'package:elola/services/base_hive_database.dart';
+
+import 'i_player_daily_data_database.dart';
+
+/// A database of the player's daily data
+class PlayerDailyDataDatabase extends BaseHiveDatabase<PlayerDailyData> implements IPlayerDailyDataDatabase {
+  //// A name for the box
+  @override
+  String get boxName => 'playerDailyData';
+
+  /// Returns `PlayerDailyData` for a given id
+  ///
+  /// If the id is not found, `null` is returned
+  PlayerDailyData _getPlayerDailyData({@required String id}) => hasData && id != null ? box.get(id) : null;
+
+  /// Updates the progress of a given day
+  @override
+  void updateProgress({@required String id, @required bool isLearned}) {
+    final playerDailyData = _getPlayerDailyData(id: id);
+    if (playerDailyData != null) {
+      if (isLearned) {
+        playerDailyData.nounsPracticed++;
+      } else {
+        playerDailyData.nounsLearned++;
+      }
+      box.put(id, playerDailyData);
+    }
+  }
+
+  /// Resets the database
+  @override
+  Future<void> reset() async => await box.deleteAll(box.keys);
+}

--- a/lib/modules/player_data/src/services/player_daily_data/player_daily_data_database.dart
+++ b/lib/modules/player_data/src/services/player_daily_data/player_daily_data_database.dart
@@ -16,18 +16,34 @@ class PlayerDailyDataDatabase extends BaseHiveDatabase<PlayerDailyData> implemen
   /// If the id is not found, `null` is returned
   PlayerDailyData _getPlayerDailyData({@required String id}) => hasData && id != null ? box.get(id) : null;
 
+  /// Ensures that data exists for an id, creating an instance if required
+  void ensureDataExists({@required String id}) {
+    PlayerDailyData playerDailyData = _getPlayerDailyData(id: id);
+    if (playerDailyData == null) {
+      playerDailyData = PlayerDailyData(id: id)..init();
+      box.put(id, playerDailyData);
+    }
+  }
+
   /// Updates the progress of a given day
   @override
   void updateProgress({@required String id, @required bool isLearned}) {
     final playerDailyData = _getPlayerDailyData(id: id);
-    if (playerDailyData != null) {
-      if (isLearned) {
-        playerDailyData.nounsPracticed++;
-      } else {
-        playerDailyData.nounsLearned++;
-      }
-      box.put(id, playerDailyData);
+    assert(playerDailyData != null, 'No daily data found for $id');
+    if (isLearned) {
+      playerDailyData.nounsPracticed++;
+    } else {
+      playerDailyData.nounsLearned++;
     }
+    box.put(id, playerDailyData);
+  }
+
+  /// Updates the time spent on a given day
+  void updateTimeSpent({@required String id, @required int timeSpent}) {
+    final playerDailyData = _getPlayerDailyData(id: id);
+    assert(playerDailyData != null, 'No daily data found for $id');
+    playerDailyData.timeSpent += timeSpent;
+    box.put(id, playerDailyData);
   }
 
   /// Resets the database

--- a/lib/modules/player_data/src/services/player_data_service.dart
+++ b/lib/modules/player_data/src/services/player_data_service.dart
@@ -8,6 +8,7 @@ import 'player_noun_data/player_noun_data_database.dart';
 class PlayerDataService implements IPlayerDataService {
   IPlayerNounDataDatabase _playerNounDataDatabase = PlayerNounDataDatabase();
 
+  /// Initializes the service
   @override
   Future<void> init() async => await _playerNounDataDatabase.init();
 
@@ -56,22 +57,15 @@ class PlayerDataService implements IPlayerDataService {
   @override
   Stream<bool> watchIsFavorite({@required String id}) => _playerNounDataDatabase.watchIsFavorite(id: id);
 
-  /// Resets the database
-  // @override
+  /// Resets the service
+  @override
   Future<void> reset() async => await _playerNounDataDatabase.reset();
 
   /// The player's `count` number of weakest nouns
   @override
   List<String> weakestNouns({@required int count}) => _playerNounDataDatabase.weakestNouns(count: count);
 
+  /// Prints the service to the console
   @override
   void debugPrint() => _playerNounDataDatabase.debugPrint();
-
-  @override
-  // TODO: implement hasData
-  bool get hasData => throw UnimplementedError();
-
-  @override
-  // TODO: implement size
-  int get size => throw UnimplementedError();
 }

--- a/lib/modules/player_data/src/services/player_data_service.dart
+++ b/lib/modules/player_data/src/services/player_data_service.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:meta/meta.dart';
 
-import 'package:elola/models/player_data.dart';
+import 'package:elola/models/player_noun_data.dart';
 import 'package:elola/services/base_hive_database.dart';
 
 import 'i_player_data_service.dart';
 
 /// A database of the player's data
-class PlayerDataService extends BaseHiveDatabase<PlayerData> implements IPlayerDataService {
+class PlayerDataService extends BaseHiveDatabase<PlayerNounData> implements IPlayerDataService {
   //// A name for the box
   @override
   String get boxName => 'playerData';
@@ -19,7 +19,7 @@ class PlayerDataService extends BaseHiveDatabase<PlayerData> implements IPlayerD
       if (!box.containsKey(id)) {
         await box.put(
           id,
-          PlayerData(id: id)..reset(),
+          PlayerNounData(id: id)..reset(),
         );
       }
     }
@@ -35,7 +35,7 @@ class PlayerDataService extends BaseHiveDatabase<PlayerData> implements IPlayerD
   /// Returns `PlayerData` for a given noun id
   ///
   /// If the id is not found, `null` is returned
-  PlayerData _getPlayerData({@required String id}) => hasData && id != null ? box.get(id) : null;
+  PlayerNounData _getPlayerData({@required String id}) => hasData && id != null ? box.get(id) : null;
 
   /// Updates the progress of a given noun
   @override
@@ -133,7 +133,7 @@ class PlayerDataService extends BaseHiveDatabase<PlayerData> implements IPlayerD
   List<String> weakestNouns({@required int count}) {
     if (hasData && count > 0) {
       if (box.values.length >= count) {
-        final copy = List<PlayerData>.from(box.values.toList());
+        final copy = List<PlayerNounData>.from(box.values.toList());
         copy.sort((a, b) => a.percentageCorrect.compareTo(b.percentageCorrect));
         final selection = copy.take(count).map((e) => e.id).toList();
         selection.shuffle();

--- a/lib/modules/player_data/src/services/player_data_service.dart
+++ b/lib/modules/player_data/src/services/player_data_service.dart
@@ -1,146 +1,77 @@
-import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:meta/meta.dart';
 
-import 'package:elola/models/player_noun_data.dart';
-import 'package:elola/services/base_hive_database.dart';
-
 import 'i_player_data_service.dart';
+import 'player_noun_data/i_player_noun_data_database.dart';
+import 'player_noun_data/player_noun_data_database.dart';
 
-/// A database of the player's data
-class PlayerDataService extends BaseHiveDatabase<PlayerNounData> implements IPlayerDataService {
-  //// A name for the box
+/// A service which interacts with player data databases
+class PlayerDataService implements IPlayerDataService {
+  IPlayerNounDataDatabase _playerNounDataDatabase = PlayerNounDataDatabase();
+
   @override
-  String get boxName => 'playerData';
+  Future<void> init() async => await _playerNounDataDatabase.init();
 
   /// Ensures that the database is in sync with a list of noun ids
   @override
-  Future<void> resync({@required Iterable<String> ids}) async {
-    for (final id in ids) {
-      if (!box.containsKey(id)) {
-        await box.put(
-          id,
-          PlayerNounData(id: id)..reset(),
-        );
-      }
-    }
-
-    for (final id in box.keys) {
-      if (!ids.contains(id)) {
-        debugPrint('Data for $id was deleted from device.');
-        await box.delete(id);
-      }
-    }
-  }
-
-  /// Returns `PlayerData` for a given noun id
-  ///
-  /// If the id is not found, `null` is returned
-  PlayerNounData _getPlayerData({@required String id}) => hasData && id != null ? box.get(id) : null;
+  Future<void> resync({@required Iterable<String> ids}) async => await _playerNounDataDatabase.resync(ids: ids);
 
   /// Updates the progress of a given noun
   @override
-  void updateProgress({@required String id, @required bool answeredCorrectly}) {
-    final playerData = _getPlayerData(id: id);
-    if (playerData != null) {
-      playerData.updateProgress(answeredCorrectly: answeredCorrectly);
-      box.put(id, playerData);
-    }
-  }
+  void updateProgress({@required String id, @required bool answeredCorrectly}) =>
+      _playerNounDataDatabase.updateProgress(id: id, answeredCorrectly: answeredCorrectly);
 
   /// Returns the player's total progress
   @override
-  double get totalProgress =>
-      hasData ? (box.values.where((playerData) => playerData.attempts > 0).length / box.values.length) : 0;
+  double get totalProgress => _playerNounDataDatabase.totalProgress;
 
   /// Watches and returns the player's total progress
   @override
-  Stream<double> get watchTotalProgress async* {
-    final events = box.watch();
-    await for (final _ in events) {
-      yield totalProgress;
-    }
-  }
+  Stream<double> get watchTotalProgress => _playerNounDataDatabase.watchTotalProgress;
 
   /// Whether the user has at least one favorite
   @override
-  bool get hasFavorites => hasData ? box.values.where((playerData) => playerData.isFavorite).isNotEmpty : false;
+  bool get hasFavorites => _playerNounDataDatabase.hasFavorites;
 
   /// Whether the user has at least one favorite
   @override
-  Stream<bool> get watchHasFavorites async* {
-    final events = box.watch();
-    await for (final _ in events) {
-      yield hasFavorites;
-    }
-  }
+  Stream<bool> get watchHasFavorites => _playerNounDataDatabase.watchHasFavorites;
 
   /// Returns an iterable of noun ids which are marked as favorites
   @override
-  List<String> get favorites => hasData
-      ? box.values.where((playerData) => playerData.isFavorite).map((playerData) => playerData.id).toList()
-      : null;
+  List<String> get favorites => _playerNounDataDatabase.favorites;
 
   /// Watches for changes and returns an iterable of noun ids which are marked as favorites
   @override
-  Stream<List<String>> get watchFavorites async* {
-    final events = box.watch();
-    await for (final _ in events) {
-      yield favorites;
-    }
-  }
+  Stream<List<String>> get watchFavorites => _playerNounDataDatabase.watchFavorites;
 
   /// Returns whether a noun is a favorite
   @override
-  bool getIsFavorite({@required String id}) {
-    final playerData = _getPlayerData(id: id);
-    if (playerData != null) {
-      return playerData.isFavorite;
-    }
-
-    return false;
-  }
+  bool getIsFavorite({@required String id}) => _playerNounDataDatabase.getIsFavorite(id: id);
 
   /// Toggles whether a noun is a favorite
   @override
-  void toggleIsFavorite({@required String id}) {
-    final playerData = _getPlayerData(id: id);
-    if (playerData != null) {
-      playerData.isFavorite = !playerData.isFavorite;
-      box.put(id, playerData);
-    }
-  }
+  void toggleIsFavorite({@required String id}) => _playerNounDataDatabase.toggleIsFavorite(id: id);
 
   /// Watches for changes on `isFavorite` for a given noun
   @override
-  Stream<bool> watchIsFavorite({@required String id}) async* {
-    final events = box.watch(key: id);
-    await for (final event in events) {
-      yield event.value.isFavorite;
-    }
-  }
+  Stream<bool> watchIsFavorite({@required String id}) => _playerNounDataDatabase.watchIsFavorite(id: id);
 
   /// Resets the database
-  @override
-  Future<void> reset() async {
-    for (final playerData in box.values) {
-      playerData.reset();
-      box.put(playerData.id, playerData);
-    }
-  }
+  // @override
+  Future<void> reset() async => await _playerNounDataDatabase.reset();
 
   /// The player's `count` number of weakest nouns
   @override
-  List<String> weakestNouns({@required int count}) {
-    if (hasData && count > 0) {
-      if (box.values.length >= count) {
-        final copy = List<PlayerNounData>.from(box.values.toList());
-        copy.sort((a, b) => a.percentageCorrect.compareTo(b.percentageCorrect));
-        final selection = copy.take(count).map((e) => e.id).toList();
-        selection.shuffle();
-        return selection;
-      }
-    }
+  List<String> weakestNouns({@required int count}) => _playerNounDataDatabase.weakestNouns(count: count);
 
-    return null;
-  }
+  @override
+  void debugPrint() => _playerNounDataDatabase.debugPrint();
+
+  @override
+  // TODO: implement hasData
+  bool get hasData => throw UnimplementedError();
+
+  @override
+  // TODO: implement size
+  int get size => throw UnimplementedError();
 }

--- a/lib/modules/player_data/src/services/player_noun_data/i_player_noun_data_database.dart
+++ b/lib/modules/player_data/src/services/player_noun_data/i_player_noun_data_database.dart
@@ -1,0 +1,45 @@
+import 'package:meta/meta.dart';
+
+import 'package:elola/services/i_database.dart';
+
+/// A database of the player's noun data
+abstract class IPlayerNounDataDatabase implements IDatabase {
+  /// Ensures that the database is in sync with a list of noun ids
+  Future<void> resync({@required Iterable<String> ids});
+
+  /// Updates the progress of a given noun
+  void updateProgress({@required String id, @required bool answeredCorrectly});
+
+  /// Returns the player's total progress
+  double get totalProgress;
+
+  /// Watches and returns the player's total progress
+  Stream<double> get watchTotalProgress;
+
+  /// Whether the user has at least one favorite
+  bool get hasFavorites;
+
+  /// Watches for changes if the user has at least one favorite
+  Stream<bool> get watchHasFavorites;
+
+  /// Returns an iterable of noun ids which are marked as favorites
+  List<String> get favorites;
+
+  /// Watches for changes and returns an iterable of noun ids which are marked as favorites
+  Stream<List<String>> get watchFavorites;
+
+  /// Returns whether a noun is a favorite
+  bool getIsFavorite({@required String id});
+
+  /// Toggles whether a noun is a favorite
+  void toggleIsFavorite({@required String id});
+
+  /// Watches for changes on `isFavorite` for a given noun
+  Stream<bool> watchIsFavorite({@required String id});
+
+  /// The player's `count` number of weakest nouns
+  List<String> weakestNouns({@required int count});
+
+  /// Returns whether a noun is learned
+  bool getIsLearned({@required String id});
+}

--- a/lib/modules/player_data/src/services/player_noun_data/player_noun_data_database.dart
+++ b/lib/modules/player_data/src/services/player_noun_data/player_noun_data_database.dart
@@ -30,6 +30,8 @@ class PlayerNounDataDatabase extends BaseHiveDatabase<PlayerNounData> implements
         await box.delete(id);
       }
     }
+
+    assert(box.length == ids.length, 'Database size mis-match.');
   }
 
   /// Returns `PlayerData` for a given noun id

--- a/lib/modules/player_data/src/services/player_noun_data/player_noun_data_database.dart
+++ b/lib/modules/player_data/src/services/player_noun_data/player_noun_data_database.dart
@@ -34,25 +34,25 @@ class PlayerNounDataDatabase extends BaseHiveDatabase<PlayerNounData> implements
     assert(box.length == ids.length, 'Database size mis-match.');
   }
 
-  /// Returns `PlayerData` for a given noun id
+  /// Returns `PlayerNounData` for a given noun id
   ///
   /// If the id is not found, `null` is returned
-  PlayerNounData _getPlayerData({@required String id}) => hasData && id != null ? box.get(id) : null;
+  PlayerNounData _getPlayerNounData({@required String id}) => hasData && id != null ? box.get(id) : null;
 
   /// Updates the progress of a given noun
   @override
   void updateProgress({@required String id, @required bool answeredCorrectly}) {
-    final playerData = _getPlayerData(id: id);
-    if (playerData != null) {
-      playerData.updateProgress(answeredCorrectly: answeredCorrectly);
-      box.put(id, playerData);
+    final playerNounData = _getPlayerNounData(id: id);
+    if (playerNounData != null) {
+      playerNounData.updateProgress(answeredCorrectly: answeredCorrectly);
+      box.put(id, playerNounData);
     }
   }
 
   /// Returns the player's total progress
   @override
   double get totalProgress =>
-      hasData ? (box.values.where((playerData) => playerData.attempts > 0).length / box.values.length) : 0;
+      hasData ? (box.values.where((playerNounData) => playerNounData.attempts > 0).length / box.values.length) : 0;
 
   /// Watches and returns the player's total progress
   @override
@@ -65,7 +65,7 @@ class PlayerNounDataDatabase extends BaseHiveDatabase<PlayerNounData> implements
 
   /// Whether the user has at least one favorite
   @override
-  bool get hasFavorites => hasData ? box.values.where((playerData) => playerData.isFavorite).isNotEmpty : false;
+  bool get hasFavorites => hasData ? box.values.where((playerNounData) => playerNounData.isFavorite).isNotEmpty : false;
 
   /// Whether the user has at least one favorite
   @override
@@ -79,7 +79,10 @@ class PlayerNounDataDatabase extends BaseHiveDatabase<PlayerNounData> implements
   /// Returns an iterable of noun ids which are marked as favorites
   @override
   List<String> get favorites => hasData
-      ? box.values.where((playerData) => playerData.isFavorite).map((playerData) => playerData.id).toList()
+      ? box.values
+          .where((playerNounData) => playerNounData.isFavorite)
+          .map((playerNounData) => playerNounData.id)
+          .toList()
       : null;
 
   /// Watches for changes and returns an iterable of noun ids which are marked as favorites
@@ -94,9 +97,9 @@ class PlayerNounDataDatabase extends BaseHiveDatabase<PlayerNounData> implements
   /// Returns whether a noun is a favorite
   @override
   bool getIsFavorite({@required String id}) {
-    final playerData = _getPlayerData(id: id);
-    if (playerData != null) {
-      return playerData.isFavorite;
+    final playerNounData = _getPlayerNounData(id: id);
+    if (playerNounData != null) {
+      return playerNounData.isFavorite;
     }
 
     return false;
@@ -105,10 +108,10 @@ class PlayerNounDataDatabase extends BaseHiveDatabase<PlayerNounData> implements
   /// Toggles whether a noun is a favorite
   @override
   void toggleIsFavorite({@required String id}) {
-    final playerData = _getPlayerData(id: id);
-    if (playerData != null) {
-      playerData.isFavorite = !playerData.isFavorite;
-      box.put(id, playerData);
+    final playerNounData = _getPlayerNounData(id: id);
+    if (playerNounData != null) {
+      playerNounData.isFavorite = !playerNounData.isFavorite;
+      box.put(id, playerNounData);
     }
   }
 
@@ -124,9 +127,9 @@ class PlayerNounDataDatabase extends BaseHiveDatabase<PlayerNounData> implements
   /// Resets the database
   @override
   Future<void> reset() async {
-    for (final playerData in box.values) {
-      playerData.reset();
-      box.put(playerData.id, playerData);
+    for (final playerNounData in box.values) {
+      playerNounData.reset();
+      box.put(playerNounData.id, playerNounData);
     }
   }
 
@@ -148,5 +151,5 @@ class PlayerNounDataDatabase extends BaseHiveDatabase<PlayerNounData> implements
 
   /// Returns whether a noun is learned
   @override
-  bool getIsLearned({@required String id}) => _getPlayerData(id: id)?.isLearned ?? false;
+  bool getIsLearned({@required String id}) => _getPlayerNounData(id: id)?.isLearned ?? false;
 }

--- a/lib/modules/player_data/src/services/player_noun_data/player_noun_data_database.dart
+++ b/lib/modules/player_data/src/services/player_noun_data/player_noun_data_database.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:meta/meta.dart';
+
+import 'package:elola/models/player_noun_data.dart';
+import 'package:elola/services/base_hive_database.dart';
+
+import 'i_player_noun_data_database.dart';
+
+/// A database of the player's data
+class PlayerNounDataDatabase extends BaseHiveDatabase<PlayerNounData> implements IPlayerNounDataDatabase {
+  //// A name for the box
+  @override
+  String get boxName => 'playerNounData';
+
+  /// Ensures that the database is in sync with a list of noun ids
+  @override
+  Future<void> resync({@required Iterable<String> ids}) async {
+    for (final id in ids) {
+      if (!box.containsKey(id)) {
+        await box.put(
+          id,
+          PlayerNounData(id: id)..reset(),
+        );
+      }
+    }
+
+    for (final id in box.keys) {
+      if (!ids.contains(id)) {
+        debugPrint('Data for $id was deleted from device.');
+        await box.delete(id);
+      }
+    }
+  }
+
+  /// Returns `PlayerData` for a given noun id
+  ///
+  /// If the id is not found, `null` is returned
+  PlayerNounData _getPlayerData({@required String id}) => hasData && id != null ? box.get(id) : null;
+
+  /// Updates the progress of a given noun
+  @override
+  void updateProgress({@required String id, @required bool answeredCorrectly}) {
+    final playerData = _getPlayerData(id: id);
+    if (playerData != null) {
+      playerData.updateProgress(answeredCorrectly: answeredCorrectly);
+      box.put(id, playerData);
+    }
+  }
+
+  /// Returns the player's total progress
+  @override
+  double get totalProgress =>
+      hasData ? (box.values.where((playerData) => playerData.attempts > 0).length / box.values.length) : 0;
+
+  /// Watches and returns the player's total progress
+  @override
+  Stream<double> get watchTotalProgress async* {
+    final events = box.watch();
+    await for (final _ in events) {
+      yield totalProgress;
+    }
+  }
+
+  /// Whether the user has at least one favorite
+  @override
+  bool get hasFavorites => hasData ? box.values.where((playerData) => playerData.isFavorite).isNotEmpty : false;
+
+  /// Whether the user has at least one favorite
+  @override
+  Stream<bool> get watchHasFavorites async* {
+    final events = box.watch();
+    await for (final _ in events) {
+      yield hasFavorites;
+    }
+  }
+
+  /// Returns an iterable of noun ids which are marked as favorites
+  @override
+  List<String> get favorites => hasData
+      ? box.values.where((playerData) => playerData.isFavorite).map((playerData) => playerData.id).toList()
+      : null;
+
+  /// Watches for changes and returns an iterable of noun ids which are marked as favorites
+  @override
+  Stream<List<String>> get watchFavorites async* {
+    final events = box.watch();
+    await for (final _ in events) {
+      yield favorites;
+    }
+  }
+
+  /// Returns whether a noun is a favorite
+  @override
+  bool getIsFavorite({@required String id}) {
+    final playerData = _getPlayerData(id: id);
+    if (playerData != null) {
+      return playerData.isFavorite;
+    }
+
+    return false;
+  }
+
+  /// Toggles whether a noun is a favorite
+  @override
+  void toggleIsFavorite({@required String id}) {
+    final playerData = _getPlayerData(id: id);
+    if (playerData != null) {
+      playerData.isFavorite = !playerData.isFavorite;
+      box.put(id, playerData);
+    }
+  }
+
+  /// Watches for changes on `isFavorite` for a given noun
+  @override
+  Stream<bool> watchIsFavorite({@required String id}) async* {
+    final events = box.watch(key: id);
+    await for (final event in events) {
+      yield event.value.isFavorite;
+    }
+  }
+
+  /// Resets the database
+  @override
+  Future<void> reset() async {
+    for (final playerData in box.values) {
+      playerData.reset();
+      box.put(playerData.id, playerData);
+    }
+  }
+
+  /// The player's `count` number of weakest nouns
+  @override
+  List<String> weakestNouns({@required int count}) {
+    if (hasData && count > 0) {
+      if (box.values.length >= count) {
+        final copy = List<PlayerNounData>.from(box.values.toList());
+        copy.sort((a, b) => a.percentageCorrect.compareTo(b.percentageCorrect));
+        final selection = copy.take(count).map((e) => e.id).toList();
+        selection.shuffle();
+        return selection;
+      }
+    }
+
+    return null;
+  }
+
+  /// Returns whether a noun is learned
+  @override
+  bool getIsLearned({@required String id}) => _getPlayerData(id: id)?.isLearned ?? false;
+}

--- a/lib/services/i_database.dart
+++ b/lib/services/i_database.dart
@@ -1,4 +1,4 @@
-/// A base interfaces which can be inherited from
+/// A base interface which databases can inherited from
 abstract class IDatabase {
   /// Initializes the database
   Future<void> init();

--- a/lib/services/i_service.dart
+++ b/lib/services/i_service.dart
@@ -1,0 +1,11 @@
+/// A base interface which services can inherited from
+abstract class IService {
+  /// Initializes the service
+  Future<void> init();
+
+  /// Resets the service
+  Future<void> reset();
+
+  /// Prints the service to the console
+  void debugPrint();
+}

--- a/lib/utils/date_time_utils.dart
+++ b/lib/utils/date_time_utils.dart
@@ -1,0 +1,8 @@
+/// A collection of helper methods for `DateTime`
+abstract class DateTimeUtils {
+  /// Returns a `DateTime` for today at midnight in UTC
+  static DateTime get todayUtcMidnight {
+    final nowUtc = DateTime.now().toUtc();
+    return DateTime.utc(nowUtc.year, nowUtc.month, nowUtc.day);
+  }
+}

--- a/lib/utils/hive_utils.dart
+++ b/lib/utils/hive_utils.dart
@@ -5,6 +5,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:elola/enums/category.dart';
 import 'package:elola/models/noun.dart';
 import 'package:elola/models/player_noun_data.dart';
+import 'package:elola/models/player_daily_data.dart';
 
 /// A collection of helper methods for hive
 class HiveUtils {
@@ -16,5 +17,6 @@ class HiveUtils {
     Hive.registerAdapter(NounAdapter());
     Hive.registerAdapter(CategoryAdapter());
     Hive.registerAdapter(PlayerNounDataAdapter());
+    Hive.registerAdapter(PlayerDailyDataAdapter());
   }
 }

--- a/lib/utils/hive_utils.dart
+++ b/lib/utils/hive_utils.dart
@@ -4,7 +4,7 @@ import 'package:path_provider/path_provider.dart';
 
 import 'package:elola/enums/category.dart';
 import 'package:elola/models/noun.dart';
-import 'package:elola/models/player_data.dart';
+import 'package:elola/models/player_noun_data.dart';
 
 /// A collection of helper methods for hive
 class HiveUtils {
@@ -15,6 +15,6 @@ class HiveUtils {
     }
     Hive.registerAdapter(NounAdapter());
     Hive.registerAdapter(CategoryAdapter());
-    Hive.registerAdapter(PlayerDataAdapter());
+    Hive.registerAdapter(PlayerNounDataAdapter());
   }
 }

--- a/lib/widgets/game_screen/game_screen.dart
+++ b/lib/widgets/game_screen/game_screen.dart
@@ -9,14 +9,46 @@ import 'package:elola/configs/constants.dart' as constants;
 import 'package:elola/widgets/common/buttons/noun_favorite_button.dart';
 import 'package:elola/widgets/game_screen/game_screen_store.dart';
 
-class GameScreen extends StatelessWidget {
+class GameScreen extends StatefulWidget {
   GameScreen({Key key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
-    final store = Provider.of<GameScreenStore>(context, listen: false);
-    store.nextRound();
+  _GameScreenState createState() => _GameScreenState();
+}
 
+class _GameScreenState extends State<GameScreen> with WidgetsBindingObserver {
+  bool hasResolvedDependencies = false;
+  GameScreenStore store;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    if (!hasResolvedDependencies) {
+      store = Provider.of<GameScreenStore>(context, listen: false);
+      store.startGame();
+      hasResolvedDependencies = true;
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    store.screenDisposed();
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) => store.didChangeAppLifecycleState(state);
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         actions: <Widget>[

--- a/lib/widgets/my_app.dart
+++ b/lib/widgets/my_app.dart
@@ -50,12 +50,10 @@ class _MyAppState extends State<MyApp> {
 
     // then IPlayerDataService
     await _playerDataService.init();
+    //await _playerDataService.reset();
     // TODO in production this could be trigger on app update
     await _playerDataService.resync(ids: _nounDatabase.nouns.map((noun) => noun.id));
-    // await _playerDataService.reset();
-    //_playerDataService.debugPrint();
-
-    assert(_nounDatabase.size == _playerDataService.size, 'Database size mismatch');
+    // _playerDataService.debugPrint();
 
     // then ISettingsDatabase
     await _settingsDatabase.init();


### PR DESCRIPTION
Adds a database to track the player's daily data, i.e. time spent, number of new nouns left and number of nouns revised.

Note that the day is determined by user's device, thus this could be abused to be set in the past/future. Moreover, a day is determined using UTC, thus not user-friendly for those in Asia/Westcoast US, however, for POC, this is acceptable.